### PR TITLE
Update: 2020-04-09

### DIFF
--- a/.setup/php/Dockerfile
+++ b/.setup/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm-alpine
+FROM php:7.4-fpm-alpine
 MAINTAINER Dominic Dambrogia <domdambrogia@gmail.com>
 
 RUN apk update; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,7 @@ services:
     networks:
       - AMP
     ports:
-      - "443:443"
-      - "80:80"
+      - "8000:80"
     volumes:
       - ./public_html/:/var/www/html/
       - ./.setup/apache/docker.apache.conf:/usr/local/apache2/conf.d/docker.apache.conf
@@ -30,7 +29,7 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=docker
     ports:
-      - "3306:3306"
+      - "3307:3306"
   # nginx:
   #   image: nginx:stable-alpine
   #   build: './.setup/nginx/'

--- a/public_html/index.php
+++ b/public_html/index.php
@@ -7,9 +7,9 @@
  *     Is for Proof of Concept only!
  */
 
-$host = 'mysql';
-$user = 'root';
-$pass = 'docker';
+$host = 'mysql'; // Matches the name of the database container.
+$user = 'root'; // For simplicity sake.
+$pass = 'docker'; // Defined in docker-compose.yml.
 
 $conn = new mysqli($host, $user, $pass);
 

--- a/readme.md
+++ b/readme.md
@@ -20,12 +20,15 @@ For more info please see `docker-compose.yml`
 ## To get started
 
     git clone https://github.com/dambrogia/docker-testing.git
-    cd docker-testing.git
+    cd docker-testing
     docker-compose up -d
 
-_Please wait up to 60 seconds for the MySQL service to be available to connect to!_
+_Please wait up to 60 seconds for the MySQL service to be available to connect to! Until then you may run into the following error:_
 
-Visit `127.0.0.1:8000` in your browser. You should see a the output from [`public_html/index.php`](https://github.com/dambrogia/docker-testing/blob/master/public_html/index.php).
+    Warning: mysqli::__construct(): (HY000/2002): Connection refused in /var/www/html/index.php on line 14
+    Connect failed: Connection refused
+
+After MySQL is ready, visit `127.0.0.1:8000` in your browser. You should see a the output from [`public_html/index.php`](https://github.com/dambrogia/docker-testing/blob/master/public_html/index.php).
 
 ## Problems and their resolutions
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ I had posted a stack overflow question and there seemed to be little documentati
 This is a very small proof of concept for running a docker environment.
 
 This test environment contains the following separate containers working together:
-- php:7.1-fpm-alpine
+- php:7.4-fpm-alpine
 - httpd:2.4-alpine
 - mysql:5.6
 
@@ -19,13 +19,13 @@ For more info please see `docker-compose.yml`
 
 ## To get started
 
-Setup a hostfile that points `127.0.0.1` to `docker.dev`
-
+    git clone https://github.com/dambrogia/docker-testing.git
+    cd docker-testing.git
     docker-compose up -d
-    
-Visit `docker.dev` in your browser.
 
 _Please wait up to 60 seconds for the MySQL service to be available to connect to!_
+
+Visit `127.0.0.1:8000` in your browser. You should see a the output from [`public_html/index.php`](https://github.com/dambrogia/docker-testing/blob/master/public_html/index.php).
 
 ## Problems and their resolutions
 


### PR DESCRIPTION
- Update PHP to 7.4
- Adjust Ports. MySql is now available on host machine at 3307 and Apache at 8000.
- Remove need to adjust /etc/hosts.
- Provide instructions.
- Explain where database credentials come from.